### PR TITLE
Angular Animate had wrong version number.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "angular-route": "1.2.26",
     "angular-resource": "1.2.26",
     "angular-ui-router": "0.2.12",
-    "angular-animate": "~1.3.x",
+    "angular-animate": "1.2.26",
     "requirejs": "~2.1.15",
     "bootstrap": "3.3.x",
     "fontawesome": "~4.2.0"


### PR DESCRIPTION
Updated to a version that works with current Angular version (1.2.26)

I was not able to update Bower with the old version of Animate. This worked for me, but I'm not sure if it works as intended. Please check it out and test for bugs/errors.
